### PR TITLE
Add option to disable plugin in jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ target
 .classpath
 .idea
 *.iml
+*~
 work

--- a/src/main/java/org/jenkinsci/plugins/dependencyqueue/BlockWhileUpstreamQueuedProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/dependencyqueue/BlockWhileUpstreamQueuedProperty.java
@@ -1,0 +1,32 @@
+package org.jenkinsci.plugins.dependencyqueue;
+
+import hudson.Extension;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
+import hudson.model.AbstractProject;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class BlockWhileUpstreamQueuedProperty extends JobProperty<AbstractProject<?, ?>> {
+    
+    //default to true for backward compatibility
+    private boolean blockWhileUpstreamQueued = true;
+    
+    @DataBoundConstructor
+    public BlockWhileUpstreamQueuedProperty(Boolean blockWhileUpstreamQueued) {
+        this.blockWhileUpstreamQueued = blockWhileUpstreamQueued;
+    }
+    
+    public boolean isBlockWhileUpstreamQueued() {
+        return blockWhileUpstreamQueued;
+    }
+    
+    @Extension
+    public static final class DescriptorImpl extends JobPropertyDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Block if upstream jobs are queued.";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/dependencyqueue/DependencyQueueDispatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/dependencyqueue/DependencyQueueDispatcher.java
@@ -5,8 +5,8 @@ import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Hudson;
 import hudson.model.Queue;
-import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskDispatcher;
+import hudson.model.queue.CauseOfBlockage;
 
 @Extension
 public class DependencyQueueDispatcher extends QueueTaskDispatcher {
@@ -14,8 +14,15 @@ public class DependencyQueueDispatcher extends QueueTaskDispatcher {
     @Override
     public CauseOfBlockage canRun(Queue.Item itemInQuestion) {
         if (itemInQuestion.task instanceof AbstractProject) {
+            AbstractProject<?,?> projectInQuestion = (AbstractProject) itemInQuestion.task;
+            BlockWhileUpstreamQueuedProperty property = projectInQuestion.getProperty(BlockWhileUpstreamQueuedProperty.class);
+            //assume old jobs won't have this property
+            if(property != null && ! property.isBlockWhileUpstreamQueued()) {
+            	//property is present and set to false.  Don't block.
+                return null;
+            }
             for (Queue.Item queuedItem : Hudson.getInstance().getQueue().getItems()) {
-                if (queuedItem.task instanceof AbstractProject && ((AbstractProject) queuedItem.task).getTransitiveDownstreamProjects().contains((AbstractProject) itemInQuestion.task)) {
+                if (queuedItem.task instanceof AbstractProject && ((AbstractProject) queuedItem.task).getTransitiveDownstreamProjects().contains(projectInQuestion)) {
                     return CauseOfBlockage.fromMessage(Messages._DependencyQueueDispatcher_UpstreamInQueue(queuedItem.task.getName()));
                 }
             }

--- a/src/main/resources/org/jenkinsci/plugins/dependencyqueue/BlockWhileUpstreamQueuedProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dependencyqueue/BlockWhileUpstreamQueuedProperty/config.jelly
@@ -1,0 +1,39 @@
+<!-- TODO: globalization -->
+<!--
+The MIT License
+
+Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Tom Huybrechts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+    xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project"
+    xmlns:this="this">  
+
+    <f:optionalBlock 
+        name="blockWhileUpstreamQueued"
+        title="Block if upstream jobs are queued" 
+        inline="true"
+        checked="${instance == null ? true : instance.blockWhileUpstreamQueued}"
+        help="/descriptor/org.jenkinsci.plugins.dependencyqueue.BlockWhileUpstreamQueuedProperty/help">       
+    </f:optionalBlock>
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/dependencyqueue/BlockWhileUpstreamQueuedProperty/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/dependencyqueue/BlockWhileUpstreamQueuedProperty/config.jelly
@@ -1,28 +1,3 @@
-<!-- TODO: globalization -->
-<!--
-The MIT License
-
-Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi, Tom Huybrechts
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
--->
-
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
     xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project"

--- a/src/main/resources/org/jenkinsci/plugins/dependencyqueue/BlockWhileUpstreamQueuedProperty/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/dependencyqueue/BlockWhileUpstreamQueuedProperty/help.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+This option causes runs of this job to block in the Jenkins queue if jobs immediately upstream of this one are also in the build queue.  This is normally the behavior that you would want.  However, in rare cases it conflicts with other plugins.
+  </p>
+</div>
+


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/JENKINS-32189.

We have a custom plugin which adds the notion of a "staged" pipeline to Jenkins which we are trying to contribute to Jenkins.  Fixing this
defect is the first step in that process.  The plugin adds the concept of "controller" and "component" jobs for each stage in the pipeline.  One thing we put in was a QueueTaskDispatcher to logically tie the jobs that make up a stage together.  We wanted to make it so that while, for example, some build was running in stage a given stage of the our pipline no other build would enter that stage.  We did this, and found that our QueueTaskDispatcher and the one implemented in the dependency-queue-plugin are incompatible with each other.  In many cases our builds ended up deadlocked in the queue.  Unfortunately, many of the plugins we use have a dependency on the dependency-queue-plugin so we could not remove it.  We needed a way to disable the plugin.  

A while back we created a customized version of the dependency-queue-plugin that allows jobs to disable the behavior.  The default is to have things continue to work as they have done in the past, but now an option "Block if upstream jobs are queued" that can be optionally deselected to disable this behavior.

We would like to get that code back into Jenkins so that everyone can benefit from it.  
